### PR TITLE
Syntax has been changed

### DIFF
--- a/Sources/GridLayout/Extensions/UIView+Extension.swift
+++ b/Sources/GridLayout/Extensions/UIView+Extension.swift
@@ -8,40 +8,48 @@
 import UIKit
 
 public extension UIView {
-    func Auto(
-        horizontalAlignment: GridHorizontalAlignment = .fill,
-        verticalAlignment: GridVerticalAlignment = .fill,
-        margin: UIEdgeInsets = .zero
-    ) -> Auto {
+    func auto() -> GridAutoCell {
         return .init(
-            horizontalAlignment: horizontalAlignment,
-            verticalAlignment: verticalAlignment,
-            margin: margin) { self }
+            cell: .init(
+                gridLength: .auto,
+                value: .zero,
+                view: self,
+                horizontalAlignment: .fill,
+                verticalAlignment: .fill,
+                maxLength: .zero,
+                minLength: .zero,
+                margin: .zero
+            )
+        )
     }
     
-    func Constant(
-        value: CGFloat,
-        horizontalAlignment: GridHorizontalAlignment = .fill,
-        verticalAlignment: GridVerticalAlignment = .fill,
-        margin: UIEdgeInsets = .zero
-    ) -> Constant {
+    func constant(_ value: CGFloat) -> GridConstantCell {
         return .init(
-            value: value,
-            horizontalAlignment: horizontalAlignment,
-            verticalAlignment: verticalAlignment,
-            margin: margin) { self }
+            cell: .init(
+                gridLength: .constant,
+                value: value,
+                view: self,
+                horizontalAlignment: .fill,
+                verticalAlignment: .fill,
+                maxLength: .zero,
+                minLength: .zero,
+                margin: .zero
+            )
+        )
     }
     
-    func Expanded(
-        value: CGFloat = 1,
-        horizontalAlignment: GridHorizontalAlignment = .fill,
-        verticalAlignment: GridVerticalAlignment = .fill,
-        margin: UIEdgeInsets = .zero
-    ) -> Expanded {
+    func expanded(_ value: CGFloat = 1) -> GridExpandedCell {
         return .init(
-            value: value,
-            horizontalAlignment: horizontalAlignment,
-            verticalAlignment: verticalAlignment,
-            margin: margin) { self }
+            cell: .init(
+                gridLength: .expanded,
+                value: value,
+                view: self,
+                horizontalAlignment: .fill,
+                verticalAlignment: .fill,
+                maxLength: .zero,
+                minLength: .zero,
+                margin: .zero
+            )
+        )
     }
 }

--- a/Sources/GridLayout/Models/GridBuilder.swift
+++ b/Sources/GridLayout/Models/GridBuilder.swift
@@ -10,23 +10,15 @@ import UIKit
 @resultBuilder
 public struct GridBuilder {
     
-    public static func buildBlock(_ components: GridContent...) -> [GridLength] {
-        var result = [GridLength]()
-        for content in components {
-            result.append(contentsOf: content.cells)
-        }
-        return result
+    public static func buildBlock(_ components: GridContent...) -> [GridCell] {
+        return components.map( {$0.cell} )
     }
     
-    public static func buildBlock(_ components: [GridLength]) -> [GridLength] {
-        return components
+    public static func buildBlock(_ components: [GridCell]...) -> [GridCell] {
+        return components.flatMap( { $0 } )
     }
     
-    public static func buildArray(_ components: [[GridLength]]) -> [GridLength] {
-        return components.flatMap({ $0 })
-    }
-    
-    public static func buildBlock(_ components: UIView...) -> [UIView] {
-        return components
+    public static func buildArray(_ components: [[GridCell]]) -> [GridCell] {
+        return components.flatMap( { $0 } )
     }
 }

--- a/Sources/GridLayout/Models/GridCell.swift
+++ b/Sources/GridLayout/Models/GridCell.swift
@@ -8,22 +8,39 @@
 import UIKit
 
 public class GridCell {
-    var value: CGFloat
-    let view: UIView
+    
     var constraints = [NSLayoutConstraint]()
-    let gridLength: GridLength
-    let horizontalAlignment: GridHorizontalAlignment
-    let verticalAlignment: GridVerticalAlignment
+    var gridLength: GridLength
+    
+    var value: CGFloat
+    var view: UIView
+    var horizontalAlignment: GridHorizontalAlignment
+    var verticalAlignment: GridVerticalAlignment
+    
+    var maxLength: CGFloat
+    var minLength: CGFloat
+    
     var margin: UIEdgeInsets
     
     var spacing: UIEdgeInsets = .zero
     
-    init(value: CGFloat, view: UIView, gridLength: GridLength, horizontalAlignment: GridHorizontalAlignment, verticalAlignment: GridVerticalAlignment, margin: UIEdgeInsets) {
+    init(
+        gridLength: GridLength,
+        value: CGFloat,
+        view: UIView,
+        horizontalAlignment: GridHorizontalAlignment,
+        verticalAlignment: GridVerticalAlignment,
+        maxLength: CGFloat,
+        minLength: CGFloat,
+        margin: UIEdgeInsets
+    ) {
+        self.gridLength = gridLength
         self.value = value
         self.view = view
-        self.gridLength = gridLength
         self.horizontalAlignment = horizontalAlignment
         self.verticalAlignment = verticalAlignment
+        self.maxLength = maxLength
+        self.minLength = minLength
         self.margin = margin
     }
 }

--- a/Sources/GridLayout/Models/GridContent.swift
+++ b/Sources/GridLayout/Models/GridContent.swift
@@ -8,71 +8,82 @@
 import UIKit
 
 public protocol GridContent {
-    var cells: [GridLength] { get }
+    var cell: GridCell { get }
 }
 
-public struct Constant: GridContent {
+public struct GridConstantCell: GridContent {
     
-    public var cells: [GridLength]
+    public var cell: GridCell
     
-    public init(value: CGFloat,
-                horizontalAlignment: GridHorizontalAlignment = .fill,
-                verticalAlignment: GridVerticalAlignment = .fill,
-                margin: UIEdgeInsets = .zero,
-                @GridBuilder content: () -> [UIView]) {
-        
-        cells = [GridLength]()
-        
-        for view in content() {
-            cells.append(.constant(value: value,
-                               view: view,
-                               horizontalAlignment: horizontalAlignment,
-                               verticalAlignment: verticalAlignment,
-                               margin: margin))
-        }
+    init(cell: GridCell) {
+        self.cell = cell
+    }
+    
+    public func horizontalAlignment(_ alignment: GridHorizontalAlignment) -> GridConstantCell {
+        cell.horizontalAlignment = alignment
+        return self
+    }
+    
+    public func verticalAlignment(_ alignment: GridVerticalAlignment) -> GridConstantCell {
+        cell.verticalAlignment = alignment
+        return self
+    }
+    
+    public func margin(_ margin: UIEdgeInsets) -> GridConstantCell {
+        cell.margin = margin
+        return self
     }
 }
 
-public struct Expanded: GridContent {
+public struct GridExpandedCell: GridContent {
     
-    public var cells: [GridLength]
+    public var cell: GridCell
     
-    public init(value: CGFloat,
-                horizontalAlignment: GridHorizontalAlignment = .fill,
-                verticalAlignment: GridVerticalAlignment = .fill,
-                margin: UIEdgeInsets = .zero,
-                @GridBuilder content: () -> [UIView]) {
-        
-        cells = [GridLength]()
-        
-        for view in content() {
-            cells.append(.expanded(value: value,
-                               view: view,
-                               horizontalAlignment: horizontalAlignment,
-                               verticalAlignment: verticalAlignment,
-                               margin: margin))
-        }
+    init(cell: GridCell) {
+        self.cell = cell
+    }
+    
+    public func horizontalAlignment(_ alignment: GridHorizontalAlignment) -> GridExpandedCell {
+        cell.horizontalAlignment = alignment
+        return self
+    }
+    
+    public func verticalAlignment(_ alignment: GridVerticalAlignment) -> GridExpandedCell {
+        cell.verticalAlignment = alignment
+        return self
+    }
+    
+    public func margin(_ margin: UIEdgeInsets) -> GridExpandedCell {
+        cell.margin = margin
+        return self
     }
 }
 
-public struct Auto: GridContent {
+public struct GridAutoCell: GridContent {
     
-    public var cells: [GridLength]
+    public var cell: GridCell
     
-    public init(horizontalAlignment: GridHorizontalAlignment = .fill,
-                verticalAlignment: GridVerticalAlignment = .fill,
-                maxSize: CGFloat = 0,
-                margin: UIEdgeInsets = .zero,
-                @GridBuilder content: () -> [UIView]) {
-        
-        cells = [GridLength]()
-        
-        for view in content() {
-            cells.append(.auto(view: view,
-                               horizontalAlignment: horizontalAlignment,
-                               verticalAlignment: verticalAlignment,
-                               maxSize: maxSize,
-                               margin: margin))
-        }
+    init(cell: GridCell) {
+        self.cell = cell
+    }
+    
+    public func horizontalAlignment(_ alignment: GridHorizontalAlignment) -> GridAutoCell {
+        cell.horizontalAlignment = alignment
+        return self
+    }
+    
+    public func verticalAlignment(_ alignment: GridVerticalAlignment) -> GridAutoCell {
+        cell.verticalAlignment = alignment
+        return self
+    }
+    
+    public func margin(_ margin: UIEdgeInsets) -> GridAutoCell {
+        cell.margin = margin
+        return self
+    }
+    
+    public func maxSize(_ maxSize: CGFloat) -> GridAutoCell {
+        cell.maxLength = maxSize
+        return self
     }
 }

--- a/Sources/GridLayout/Models/GridLength.swift
+++ b/Sources/GridLayout/Models/GridLength.swift
@@ -8,21 +8,7 @@
 import UIKit
 
 public enum GridLength {
-    case expanded(value: CGFloat,
-              view: UIView,
-              horizontalAlignment: GridHorizontalAlignment = .fill,
-              verticalAlignment: GridVerticalAlignment = .fill,
-              margin: UIEdgeInsets = .zero)
-    
-    case constant(value: CGFloat,
-                  view: UIView,
-                  horizontalAlignment: GridHorizontalAlignment = .fill,
-                  verticalAlignment: GridVerticalAlignment = .fill,
-                  margin: UIEdgeInsets = .zero)
-    
-    case auto(view: UIView,
-              horizontalAlignment: GridHorizontalAlignment = .fill,
-              verticalAlignment: GridVerticalAlignment = .fill,
-              maxSize: CGFloat = 0,
-              margin: UIEdgeInsets = .zero)
+    case expanded
+    case auto
+    case constant
 }


### PR DESCRIPTION
Changed: Syntax being used to build grids is now changed. Every parameter is now being set by a latter function.
Example:
`view
    .Expanded(horizontalAlignment: .autoLeft)
`
is now changed into
`view
    .expanded()
    .horizontaAlignment(.autoLeft)
`