### PR TITLE
Fix: Swap arrangement error when both views are in the same subgrid

### DIFF
--- a/Sources/GridLayout/Grid/GridConfiguration.swift
+++ b/Sources/GridLayout/Grid/GridConfiguration.swift
@@ -61,7 +61,7 @@ extension Grid {
         else { fatalError("In Grid.swapArrangement: Views provided as parameters has to be subviews of the grid.") }
         
         if first.subgrid === second.subgrid {
-            contents.swapAt(first.index, second.index)
+            first.subgrid.contents.swapAt(first.index, second.index)
         } else {
             swapArrangementBetweenSubgrids(first, second)
         }


### PR DESCRIPTION
**Fix:** When "swap arrangement" is called for 2 views that are in a same sub grid, program was getting crashed.